### PR TITLE
Refactor party | Reorganize Pytest fixtures

### DIFF
--- a/admin.sh
+++ b/admin.sh
@@ -170,7 +170,7 @@ scriptController() {
             case ${arg} in
                 m)
                     echo "m: "${$OPTARG}
-                    docker compose run --rm server alembic revision --autogenerate -m "$OPTARG"
+                    docker compose run --rm server alembic revision --autogenerate -m "'${OPTARG}'"
                     exit 0
                     ;;
             esac
@@ -263,7 +263,7 @@ scriptController() {
             echo "Running server tests! :D"
             echo "======================================================================================"
             echo ""
-            docker compose run -e DATABASE_NAME=test_the_money_maker -e ENV=test --rm server python -m pytest -s --import-mode=append ${@:3}
+            docker compose run -e DATABASE_NAME=test_the_money_maker -e ENV=test --rm server python -m pytest -s --import-mode=append  # "'${@:3}'"
         fi
     elif [ "$1" == "clean" ]; then
         echo ""

--- a/server/conftest.py
+++ b/server/conftest.py
@@ -1,4 +1,3 @@
-import arrow
 import os
 import pytest
 import requests_mock
@@ -9,6 +8,7 @@ from starlette.testclient import TestClient
 from api.app import app
 from db import db_session, engine, db_session_dependency
 from models.user.factories import UserFactory
+from utils.testing_mocks import get_mock_utcnow
 
 
 def pytest_sessionstart(session):
@@ -48,10 +48,6 @@ def server_api_client(mock_db_session):
 def http_requests_mock():
     with requests_mock.Mocker(real_http=True) as mock:
         yield mock
-
-
-def get_mock_utcnow():
-    return arrow.get(2024, 4, 19).to("utc")
 
 
 @pytest.fixture

--- a/server/nlp_ssa/api/routes/api/article_data/tests/conftest.py
+++ b/server/nlp_ssa/api/routes/api/article_data/tests/conftest.py
@@ -1,0 +1,99 @@
+import pytest
+
+from models.article_data import ArticleData
+from models.article_data.factories import ArticleDataFactory
+from models.stock.factories import StockFactory
+from utils.testing_mocks import get_may_the_4th
+
+
+@pytest.fixture
+def mock_stocks(mock_db_session):
+    ntdof_stock = StockFactory(quote_stock_symbol="NTDOF")
+    tsla_stock = StockFactory(quote_stock_symbol="TSLA")
+
+    mock_db_session.commit()
+
+    return ntdof_stock, tsla_stock
+
+
+@pytest.fixture
+def mock_ntdof_article_data(mock_db_session, mock_stocks):
+    ntdof_stock, _ = mock_stocks
+
+    may_the_4th = get_may_the_4th()
+
+    ntdof_article_data = [
+        ArticleDataFactory(
+            quote_stock_symbol=ntdof_stock.quote_stock_symbol,
+            updated_at=may_the_4th.shift(days=-11),
+        ),
+        ArticleDataFactory(
+            quote_stock_symbol=ntdof_stock.quote_stock_symbol,
+            updated_at=may_the_4th.shift(days=-17),
+        ),
+        ArticleDataFactory(
+            quote_stock_symbol=ntdof_stock.quote_stock_symbol,
+            updated_at=may_the_4th.shift(days=-20),
+        ),
+        ArticleDataFactory(
+            quote_stock_symbol=ntdof_stock.quote_stock_symbol,
+            updated_at=may_the_4th.shift(days=-23),
+        ),
+        ArticleDataFactory(
+            quote_stock_symbol=ntdof_stock.quote_stock_symbol,
+            updated_at=may_the_4th.shift(days=-30),
+        ),
+        ArticleDataFactory(
+            quote_stock_symbol=ntdof_stock.quote_stock_symbol,
+            updated_at=may_the_4th.shift(days=-50),
+        ),
+        ArticleDataFactory(
+            quote_stock_symbol=ntdof_stock.quote_stock_symbol,
+        ),
+    ]
+
+    mock_db_session.commit()
+
+    return [ArticleData.model_validate(ad) for ad in ntdof_article_data]
+
+
+@pytest.fixture
+def mock_tsla_article_data(mock_db_session, mock_stocks):
+    _, tsla_stock = mock_stocks
+
+    may_the_4th = get_may_the_4th()
+
+    tsla_article_data = [
+        ArticleDataFactory(
+            quote_stock_symbol=tsla_stock.quote_stock_symbol,
+            updated_at=may_the_4th.shift(days=-6),
+        ),
+        ArticleDataFactory(
+            quote_stock_symbol=tsla_stock.quote_stock_symbol,
+            updated_at=may_the_4th.shift(days=-12),
+        ),
+        ArticleDataFactory(
+            quote_stock_symbol=tsla_stock.quote_stock_symbol,
+            updated_at=may_the_4th.shift(days=-13),
+        ),
+        ArticleDataFactory(
+            quote_stock_symbol=tsla_stock.quote_stock_symbol,
+            updated_at=may_the_4th.shift(days=-18),
+        ),
+        ArticleDataFactory(
+            quote_stock_symbol=tsla_stock.quote_stock_symbol,
+            updated_at=may_the_4th.shift(days=-22),
+        ),
+        ArticleDataFactory(
+            quote_stock_symbol=tsla_stock.quote_stock_symbol,
+            updated_at=may_the_4th.shift(days=-29),
+        ),
+        ArticleDataFactory(
+            quote_stock_symbol=tsla_stock.quote_stock_symbol,
+            updated_at=may_the_4th.shift(days=-37),
+        ),
+    ]
+
+    mock_db_session.commit()
+
+    return [ArticleData.model_validate(ad) for ad in tsla_article_data]

--- a/server/nlp_ssa/api/routes/api/article_data/tests/test_route_handlers.py
+++ b/server/nlp_ssa/api/routes/api/article_data/tests/test_route_handlers.py
@@ -1,5 +1,3 @@
-import pytest
-
 from api.routes.api.article_data.models import GroupedArticleData
 from api.routes.api.article_data.route_handlers import (
     get_all_article_data,
@@ -8,95 +6,6 @@ from api.routes.api.article_data.route_handlers import (
 from models.article_data import ArticleData
 from models.article_data.factories import ArticleDataFactory
 from models.stock.factories import StockFactory
-
-
-@pytest.fixture
-def mock_stocks(mock_db_session):
-    ntdof_stock = StockFactory(quote_stock_symbol="NTDOF")
-    tsla_stock = StockFactory(quote_stock_symbol="TSLA")
-
-    mock_db_session.commit()
-
-    return ntdof_stock, tsla_stock
-
-
-@pytest.fixture
-def mock_ntdof_article_data(mock_db_session, mock_stocks, mock_utcnow):
-    ntdof_stock, _ = mock_stocks
-
-    ntdof_article_data = [
-        ArticleDataFactory(
-            quote_stock_symbol=ntdof_stock.quote_stock_symbol,
-            updated_at=mock_utcnow.shift(days=-11),
-        ),
-        ArticleDataFactory(
-            quote_stock_symbol=ntdof_stock.quote_stock_symbol,
-            updated_at=mock_utcnow.shift(days=-17),
-        ),
-        ArticleDataFactory(
-            quote_stock_symbol=ntdof_stock.quote_stock_symbol,
-            updated_at=mock_utcnow.shift(days=-20),
-        ),
-        ArticleDataFactory(
-            quote_stock_symbol=ntdof_stock.quote_stock_symbol,
-            updated_at=mock_utcnow.shift(days=-23),
-        ),
-        ArticleDataFactory(
-            quote_stock_symbol=ntdof_stock.quote_stock_symbol,
-            updated_at=mock_utcnow.shift(days=-30),
-        ),
-        ArticleDataFactory(
-            quote_stock_symbol=ntdof_stock.quote_stock_symbol,
-            updated_at=mock_utcnow.shift(days=-50),
-        ),
-        ArticleDataFactory(
-            quote_stock_symbol=ntdof_stock.quote_stock_symbol,
-        ),
-    ]
-
-    mock_db_session.commit()
-
-    return [ArticleData.model_validate(ad) for ad in ntdof_article_data]
-
-
-@pytest.fixture
-def mock_tsla_article_data(mock_db_session, mock_stocks, mock_utcnow):
-    _, tsla_stock = mock_stocks
-
-    tsla_article_data = [
-        ArticleDataFactory(
-            quote_stock_symbol=tsla_stock.quote_stock_symbol,
-            updated_at=mock_utcnow.shift(days=-6),
-        ),
-        ArticleDataFactory(
-            quote_stock_symbol=tsla_stock.quote_stock_symbol,
-            updated_at=mock_utcnow.shift(days=-12),
-        ),
-        ArticleDataFactory(
-            quote_stock_symbol=tsla_stock.quote_stock_symbol,
-            updated_at=mock_utcnow.shift(days=-13),
-        ),
-        ArticleDataFactory(
-            quote_stock_symbol=tsla_stock.quote_stock_symbol,
-            updated_at=mock_utcnow.shift(days=-18),
-        ),
-        ArticleDataFactory(
-            quote_stock_symbol=tsla_stock.quote_stock_symbol,
-            updated_at=mock_utcnow.shift(days=-22),
-        ),
-        ArticleDataFactory(
-            quote_stock_symbol=tsla_stock.quote_stock_symbol,
-            updated_at=mock_utcnow.shift(days=-29),
-        ),
-        ArticleDataFactory(
-            quote_stock_symbol=tsla_stock.quote_stock_symbol,
-            updated_at=mock_utcnow.shift(days=-37),
-        ),
-    ]
-
-    mock_db_session.commit()
-
-    return [ArticleData.model_validate(ad) for ad in tsla_article_data]
 
 
 def test_get_all_article_data_one_stock(

--- a/server/nlp_ssa/migrations/versions/2024_03_10_2004-b6fb17fa3666_create_users_and_sentiment_analyses_.py
+++ b/server/nlp_ssa/migrations/versions/2024_03_10_2004-b6fb17fa3666_create_users_and_sentiment_analyses_.py
@@ -39,12 +39,14 @@ def upgrade() -> None:
         sa.Column(
             "created_at",
             db.db.ArrowDateClass(timezone=True),
+            # TODO: this should probably use sa.func.now()
             server_default=sa.text("now()"),
             nullable=False,
         ),
         sa.Column(
             "updated_at",
             db.db.ArrowDateClass(timezone=True),
+            # TODO: this should probably use sa.func.now()
             server_default=sa.text("now()"),
             nullable=False,
         ),
@@ -60,12 +62,14 @@ def upgrade() -> None:
         sa.Column(
             "created_at",
             db.db.ArrowDateClass(timezone=True),
+            # TODO: this should probably use sa.func.now()
             server_default=sa.text("now()"),
             nullable=False,
         ),
         sa.Column(
             "updated_at",
             db.db.ArrowDateClass(timezone=True),
+            # TODO: this should probably use sa.func.now()
             server_default=sa.text("now()"),
             nullable=False,
         ),

--- a/server/nlp_ssa/migrations/versions/2024_03_15_0248-41b5c3375bb6_create_stocks_table.py
+++ b/server/nlp_ssa/migrations/versions/2024_03_15_0248-41b5c3375bb6_create_stocks_table.py
@@ -29,12 +29,14 @@ def upgrade() -> None:
         sa.Column(
             "created_at",
             db.db.ArrowDateClass(timezone=True),
+            # TODO: this should probably use sa.func.now()
             server_default=sa.text("now()"),
             nullable=False,
         ),
         sa.Column(
             "updated_at",
             db.db.ArrowDateClass(timezone=True),
+            # TODO: this should probably use sa.func.now()
             server_default=sa.text("now()"),
             nullable=False,
         ),

--- a/server/nlp_ssa/migrations/versions/2024_03_16_0434-f6c3fbfda286_create_analysis_views_table.py
+++ b/server/nlp_ssa/migrations/versions/2024_03_16_0434-f6c3fbfda286_create_analysis_views_table.py
@@ -30,12 +30,14 @@ def upgrade() -> None:
         sa.Column(
             "created_at",
             db.db.ArrowDateClass(timezone=True),
+            # TODO: this should probably use sa.func.now()
             server_default=sa.text("now()"),
             nullable=False,
         ),
         sa.Column(
             "updated_at",
             db.db.ArrowDateClass(timezone=True),
+            # TODO: this should probably use sa.func.now()
             server_default=sa.text("now()"),
             nullable=False,
         ),

--- a/server/nlp_ssa/migrations/versions/2024_04_27_1557-d73a47d9cef8_create_article_data_table.py
+++ b/server/nlp_ssa/migrations/versions/2024_04_27_1557-d73a47d9cef8_create_article_data_table.py
@@ -32,12 +32,14 @@ def upgrade() -> None:
         sa.Column(
             "created_at",
             db.db.ArrowDateClass(timezone=True),
+            # TODO: this should probably use sa.func.now()
             server_default=sa.text("now()"),
             nullable=False,
         ),
         sa.Column(
             "updated_at",
             db.db.ArrowDateClass(timezone=True),
+            # TODO: this should probably use sa.func.now()
             server_default=sa.text("now()"),
             nullable=False,
         ),

--- a/server/nlp_ssa/models/analysis_view/tests/conftest.py
+++ b/server/nlp_ssa/models/analysis_view/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+from models.analysis_view import AnalysisViewFacade
+
+
+@pytest.fixture
+def analysis_view_facade(mock_db_session):
+    return AnalysisViewFacade(db_session=mock_db_session)

--- a/server/nlp_ssa/models/analysis_view/tests/test_db.py
+++ b/server/nlp_ssa/models/analysis_view/tests/test_db.py
@@ -1,7 +1,6 @@
 import arrow
 import pytest
 from sqlalchemy import select, and_
-from unittest import mock
 from uuid import UUID
 
 from models.analysis_view import AnalysisViewDB
@@ -9,12 +8,6 @@ from models.analysis_view.factories import AnalysisViewFactory
 
 
 mock_source_group_id = UUID("16ec77ca-7dd0-483d-be53-f625618d66ab")
-
-
-@pytest.fixture(autouse=True)
-def mock_utcnow():
-    mock.patch("arrow.utcnow", return_value=arrow.get(2024, 3, 11))
-    return mock_utcnow
 
 
 @pytest.fixture
@@ -43,8 +36,8 @@ def test_analysis_view_db_no_user(mock_db_session, expected_analysis_view_dict):
     assert result.source_group_id == expected_analysis_view_dict["source_group_id"]
     # assert result.owner_id == expected_analysis_view_dict["owner_id"]
     assert result.user_id is None
-    assert result.created_at == arrow.get(2020, 4, 15)
-    assert result.updated_at == arrow.get(2020, 4, 15)
+    assert result.created_at == arrow.get(2024, 4, 1).to("utc")
+    assert result.updated_at == arrow.get(2024, 4, 1).to("utc")
 
 
 def test_analysis_view_db_with_user(
@@ -67,5 +60,5 @@ def test_analysis_view_db_with_user(
     assert result.source_group_id == expected_analysis_view_dict["source_group_id"]
     # assert result.owner_id == expected_analysis_view_dict["owner_id"]
     assert result.user_id == mock_user.id
-    assert result.created_at == arrow.get(2020, 4, 15)
-    assert result.updated_at == arrow.get(2020, 4, 15)
+    assert result.created_at == arrow.get(2024, 4, 1).to("utc")
+    assert result.updated_at == arrow.get(2024, 4, 1).to("utc")

--- a/server/nlp_ssa/models/analysis_view/tests/test_facade.py
+++ b/server/nlp_ssa/models/analysis_view/tests/test_facade.py
@@ -4,11 +4,6 @@ from models.analysis_view import AnalysisView, AnalysisViewFacade
 from models.analysis_view.factories import AnalysisViewFactory
 
 
-@pytest.fixture
-def analysis_view_facade(mock_db_session):
-    return AnalysisViewFacade(db_session=mock_db_session)
-
-
 def test_get_one_by_id(mock_db_session, analysis_view_facade):
     mock_analysis_view = AnalysisViewFactory()
     mock_db_session.commit()

--- a/server/nlp_ssa/models/article_data/tests/conftest.py
+++ b/server/nlp_ssa/models/article_data/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+from models.article_data import ArticleDataFacade
+
+
+@pytest.fixture
+def article_data_facade(mock_db_session):
+    return ArticleDataFacade(db_session=mock_db_session)

--- a/server/nlp_ssa/models/article_data/tests/test_db.py
+++ b/server/nlp_ssa/models/article_data/tests/test_db.py
@@ -1,18 +1,11 @@
 import arrow
 import pytest
 from sqlalchemy import select, and_
-from unittest import mock
 from uuid import UUID
 
 from models.article_data import ArticleDataDB
 from models.article_data.factories import ArticleDataFactory
 from models.stock.factories import StockFactory
-
-
-@pytest.fixture(autouse=True)
-def mock_utcnow():
-    mock.patch("arrow.utcnow", return_value=arrow.get(2024, 3, 11))
-    return mock_utcnow
 
 
 @pytest.fixture
@@ -56,5 +49,5 @@ def test_article_data_db(mock_db_session, expected_article_data_dict):
     assert result.source_url == expected_article_data_dict["source_url"]
     assert result.raw_content == expected_article_data_dict["raw_content"]
     assert result.sentence_tokens == expected_article_data_dict["sentence_tokens"]
-    assert result.created_at == arrow.get(2020, 4, 15).to("utc")
-    assert result.updated_at == arrow.get(2020, 4, 15).to("utc")
+    assert result.created_at == arrow.get(2024, 4, 1).to("utc")
+    assert result.updated_at == arrow.get(2024, 4, 1).to("utc")

--- a/server/nlp_ssa/models/article_data/tests/test_facade.py
+++ b/server/nlp_ssa/models/article_data/tests/test_facade.py
@@ -10,18 +10,7 @@ from models.article_data import (
 )
 from models.article_data.factories import ArticleDataFactory
 from models.stock.factories import StockFactory
-
-
-@pytest.fixture(autouse=True)
-def mock_facade_now(mocker, mock_utcnow):
-    return mocker.patch(
-        "nlp_ssa.models.article_data.facade.arrow.utcnow", return_value=mock_utcnow
-    )
-
-
-@pytest.fixture
-def article_data_facade(mock_db_session):
-    return ArticleDataFacade(db_session=mock_db_session)
+from utils.testing_mocks import get_mock_utcnow
 
 
 def test_get_one_by_id(article_data_facade, mock_db_session):
@@ -97,9 +86,7 @@ def test_get_all_by_stock_symbol_no_results(article_data_facade):
     assert results == []
 
 
-def test_create_or_update_new_article_data(
-    article_data_facade, mock_db_session, mock_utcnow, mock_facade_now
-):
+def test_create_or_update_new_article_data(article_data_facade, mock_db_session):
     StockFactory(quote_stock_symbol="NTDOF")
     mock_db_session.commit()
 
@@ -125,9 +112,7 @@ def test_create_or_update_new_article_data(
     assert result.source_url == article_data_dict["source_url"]
     assert result.raw_content == article_data_dict["raw_content"]
     assert result.sentence_tokens == article_data_dict["sentence_tokens"]
-    # TODO: not sure why the mocks in the test fixtures aren't working :']
-    # assert result.created_at == mock_utcnow
-    # assert result.updated_at == mock_utcnow
+    # TODO: find better way to mock server 'now' function
     assert isinstance(result.created_at, arrow.Arrow)
     assert isinstance(result.updated_at, arrow.Arrow)
 
@@ -176,6 +161,9 @@ def test_create_or_update_existing_article_data(article_data_facade, mock_db_ses
     assert result.source_url == mock_article_data.source_url
     assert result.raw_content == updated_article_data_dict["raw_content"]
     assert result.sentence_tokens == updated_article_data_dict["sentence_tokens"]
+    assert result.created_at == get_mock_utcnow()
+    # TODO: find better way to mock server 'now' function
+    assert isinstance(result.updated_at, arrow.Arrow)
 
     assert result.author == ""
     assert result.last_updated_date is None

--- a/server/nlp_ssa/models/mixins/factories.py
+++ b/server/nlp_ssa/models/mixins/factories.py
@@ -1,7 +1,8 @@
-import arrow
 import factory
+
+from utils.testing_mocks import get_mock_utcnow
 
 
 class TimestampsMixinFactory(factory.alchemy.SQLAlchemyModelFactory):
-    created_at = arrow.get(2020, 4, 15)
-    updated_at = arrow.get(2020, 4, 15)
+    created_at = get_mock_utcnow()
+    updated_at = get_mock_utcnow()

--- a/server/nlp_ssa/models/sentiment_analysis/tests/conftest.py
+++ b/server/nlp_ssa/models/sentiment_analysis/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+from models.sentiment_analysis import SentimentAnalysisFacade
+
+
+@pytest.fixture
+def sentiment_analysis_facade(mock_db_session):
+    return SentimentAnalysisFacade(db_session=mock_db_session)

--- a/server/nlp_ssa/models/sentiment_analysis/tests/test_db.py
+++ b/server/nlp_ssa/models/sentiment_analysis/tests/test_db.py
@@ -1,7 +1,6 @@
 import arrow
 import pytest
 from sqlalchemy import select, and_
-from unittest import mock
 from uuid import UUID
 
 from models.sentiment_analysis import (
@@ -10,12 +9,6 @@ from models.sentiment_analysis import (
 )
 from models.sentiment_analysis.factories import SentimentAnalysisFactory
 from models.stock.factories import StockFactory
-
-
-@pytest.fixture(autouse=True)
-def mock_utcnow():
-    mock.patch("arrow.utcnow", return_value=arrow.get(2024, 3, 11))
-    return mock_utcnow
 
 
 @pytest.fixture
@@ -54,5 +47,5 @@ def test_sentiment_analysis_db(mock_db_session, expected_sentiment_analysis_dict
     )
     assert result.score == expected_sentiment_analysis_dict["score"]
     assert result.sentiment.value == expected_sentiment_analysis_dict["sentiment"]
-    assert result.created_at == arrow.get(2020, 4, 15).to("utc")
-    assert result.updated_at == arrow.get(2020, 4, 15).to("utc")
+    assert result.created_at == arrow.get(2024, 4, 1).to("utc")
+    assert result.updated_at == arrow.get(2024, 4, 1).to("utc")

--- a/server/nlp_ssa/models/sentiment_analysis/tests/test_facade.py
+++ b/server/nlp_ssa/models/sentiment_analysis/tests/test_facade.py
@@ -8,11 +8,6 @@ from models.sentiment_analysis.factories import SentimentAnalysisFactory
 from models.stock.factories import StockFactory
 
 
-@pytest.fixture
-def sentiment_analysis_facade(mock_db_session):
-    return SentimentAnalysisFacade(db_session=mock_db_session)
-
-
 def test_get_one_by_id(mock_db_session, sentiment_analysis_facade):
     mock_stock = StockFactory()
     mock_db_session.commit()

--- a/server/nlp_ssa/models/stock/factories.py
+++ b/server/nlp_ssa/models/stock/factories.py
@@ -1,4 +1,3 @@
-import arrow
 import factory
 import uuid
 

--- a/server/nlp_ssa/models/stock/tests/conftest.py
+++ b/server/nlp_ssa/models/stock/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+from models.stock import StockFacade
+
+
+@pytest.fixture
+def stock_facade(mock_db_session):
+    return StockFacade(db_session=mock_db_session)

--- a/server/nlp_ssa/models/stock/tests/test_db.py
+++ b/server/nlp_ssa/models/stock/tests/test_db.py
@@ -1,17 +1,10 @@
 import arrow
 import pytest
 from sqlalchemy import select, and_
-from unittest import mock
 from uuid import UUID
 
 from models.stock import StockDB
 from models.stock.factories import StockFactory
-
-
-@pytest.fixture(autouse=True)
-def mock_utcnow():
-    mock.patch("arrow.utcnow", return_value=arrow.get(2024, 3, 11))
-    return mock_utcnow
 
 
 @pytest.fixture
@@ -39,5 +32,5 @@ def test_stock_db(mock_db_session, expected_stock_dict):
     assert result.id == expected_stock_dict["id"]
     assert result.quote_stock_symbol == expected_stock_dict["quote_stock_symbol"]
     assert result.full_stock_symbol == expected_stock_dict["full_stock_symbol"]
-    assert result.created_at == arrow.get(2020, 4, 15)
-    assert result.updated_at == arrow.get(2020, 4, 15)
+    assert result.created_at == arrow.get(2024, 4, 1).to("utc")
+    assert result.updated_at == arrow.get(2024, 4, 1).to("utc")

--- a/server/nlp_ssa/models/stock/tests/test_facade.py
+++ b/server/nlp_ssa/models/stock/tests/test_facade.py
@@ -7,11 +7,6 @@ from models.stock.stock import Stock
 from models.stock.factories import StockFactory
 
 
-@pytest.fixture
-def stock_facade(mock_db_session):
-    return StockFacade(db_session=mock_db_session)
-
-
 def test_get_one_by_id(mock_db_session, stock_facade):
     mock_stock = StockFactory()
     mock_db_session.commit()

--- a/server/nlp_ssa/models/user/tests/conftest.py
+++ b/server/nlp_ssa/models/user/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+from models.user import UserFacade
+
+
+@pytest.fixture
+def user_facade(mock_db_session):
+    return UserFacade(db_session=mock_db_session)

--- a/server/nlp_ssa/models/user/tests/test_db.py
+++ b/server/nlp_ssa/models/user/tests/test_db.py
@@ -1,17 +1,10 @@
 import arrow
 import pytest
 from sqlalchemy import select, and_
-from unittest import mock
 from uuid import UUID
 
 from models.user import UserDB
 from models.user.factories import UserFactory
-
-
-@pytest.fixture(autouse=True)
-def mock_utcnow():
-    mock.patch("arrow.utcnow", return_value=arrow.get(2024, 3, 11))
-    return mock_utcnow
 
 
 @pytest.fixture
@@ -24,7 +17,7 @@ def expected_user_dict():
     )
 
 
-def test_user_db(mock_db_session, expected_user_dict):
+def test_user_db(expected_user_dict, mock_db_session):
     user = UserFactory(**expected_user_dict)
     mock_db_session.commit()
 
@@ -38,5 +31,5 @@ def test_user_db(mock_db_session, expected_user_dict):
     assert result.username == expected_user_dict["username"]
     assert result.first_name == expected_user_dict["first_name"]
     assert result.last_name == expected_user_dict["last_name"]
-    assert result.created_at == arrow.get(2020, 4, 15)
-    assert result.updated_at == arrow.get(2020, 4, 15)
+    assert result.created_at == arrow.get(2024, 4, 1).to("utc")
+    assert result.updated_at == arrow.get(2024, 4, 1).to("utc")

--- a/server/nlp_ssa/models/user/tests/test_facade.py
+++ b/server/nlp_ssa/models/user/tests/test_facade.py
@@ -11,14 +11,8 @@ from models.user.factories import UserFactory
 
 @pytest.fixture()
 def mock_facade_now(mocker, mock_utcnow):
-    # mock_facade_urcnow = mocker.patch("nlp_ssa.models.user.facade.arrow.utcnow")
     mock_facade_urcnow = mocker.patch("nlp_ssa.models.user.facade.arrow.utcnow")
     mock_facade_urcnow.return_value = mock_utcnow
-
-
-@pytest.fixture
-def user_facade(mock_db_session):
-    return UserFacade(db_session=mock_db_session)
 
 
 def test_get_one_by_id(mock_db_session, user_facade):

--- a/server/nlp_ssa/utils/testing_mocks.py
+++ b/server/nlp_ssa/utils/testing_mocks.py
@@ -2,4 +2,5 @@ import arrow
 
 
 def get_mock_utcnow():
+    """Return arrow date for April 1st, 2024 UTC"""
     return arrow.get(2024, 4, 1).to("utc")

--- a/server/nlp_ssa/utils/testing_mocks.py
+++ b/server/nlp_ssa/utils/testing_mocks.py
@@ -4,3 +4,8 @@ import arrow
 def get_mock_utcnow():
     """Return arrow date for April 1st, 2024 UTC"""
     return arrow.get(2024, 4, 1).to("utc")
+
+
+def get_may_the_4th():
+    """Return arrow date for May 4th, 2024 UTC"""
+    return arrow.get(2024, 5, 4).to("utc")

--- a/server/nlp_ssa/utils/testing_mocks.py
+++ b/server/nlp_ssa/utils/testing_mocks.py
@@ -1,0 +1,5 @@
+import arrow
+
+
+def get_mock_utcnow():
+    return arrow.get(2024, 4, 1).to("utc")


### PR DESCRIPTION
# Description

Reorganize Pytest fixtures utilizing [conftest.py files](https://docs.pytest.org/en/6.2.x/fixture.html#conftest-py-sharing-fixtures-across-multiple-files)
